### PR TITLE
build: update nanoarrow to 0.9.0

### DIFF
--- a/.github/workflows/NodeJS.yml
+++ b/.github/workflows/NodeJS.yml
@@ -48,6 +48,6 @@ jobs:
       - name: Run JS tests
         run: |
           ARROW_EXTENSION_BINARY_PATH="$(pwd)/build/release/extension/nanoarrow/nanoarrow.duckdb_extension" \
-            lldb --batch -o run -o "thread backtrace all" -- \
+            lldb --batch -o run -k "thread backtrace all" -- \
             node --expose-gc node_modules/mocha/bin/mocha.js -R spec \
             --timeout 480000 --exclude 'test/*.ts' -- "test/nodejs/**/*.js"

--- a/.github/workflows/NodeJS.yml
+++ b/.github/workflows/NodeJS.yml
@@ -47,4 +47,7 @@ jobs:
 
       - name: Run JS tests
         run: |
-          make test_release_js
+          ARROW_EXTENSION_BINARY_PATH="$(pwd)/build/release/extension/nanoarrow/nanoarrow.duckdb_extension" \
+            lldb --batch -o run -o "thread backtrace all" -- \
+            node --expose-gc node_modules/mocha/bin/mocha.js -R spec \
+            --timeout 480000 --exclude 'test/*.ts' -- "test/nodejs/**/*.js"

--- a/.github/workflows/NodeJS.yml
+++ b/.github/workflows/NodeJS.yml
@@ -41,13 +41,10 @@ jobs:
         run: |
           cd duckdb
           git fetch --tags
-          git checkout v1.5-variegata
+          git checkout v1.5.5
           cd ..
           GEN=ninja make release
 
       - name: Run JS tests
         run: |
-          ARROW_EXTENSION_BINARY_PATH="$(pwd)/build/release/extension/nanoarrow/nanoarrow.duckdb_extension" \
-            lldb --batch -o run -k "thread backtrace all" -- \
-            node --expose-gc node_modules/mocha/bin/mocha.js -R spec \
-            --timeout 480000 --exclude 'test/*.ts' -- "test/nodejs/**/*.js"
+          make test_release_js

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,8 @@ set(TARGET_NAME nanoarrow)
 set(NANOARROW_IPC ON)
 set(NANOARROW_NAMESPACE "DuckDBExt${TARGET_NAME}")
 fetchcontent_declare(nanoarrow
-                     URL "https://github.com/apache/arrow-nanoarrow/archive/4bf5a9322626e95e3717e43de7616c0a256179eb.zip"
-                     URL_HASH SHA256=49d588ee758a2a1d099ed4525c583a04adf71ce40405011e0190aa1e75e61b59
+                     URL "https://github.com/apache/arrow-nanoarrow/archive/9fad80292360d0f3978264c11ba865ccc94020d8.zip"
+                     URL_HASH SHA256=7dae6a078981463c7cbf9d430c27056812cdac0963e368f3f1ea6736c5f8280f
 )
 fetchcontent_makeavailable(nanoarrow)
 

--- a/src/include/ipc/stream_reader/base_stream_reader.hpp
+++ b/src/include/ipc/stream_reader/base_stream_reader.hpp
@@ -22,17 +22,6 @@
 namespace duckdb {
 namespace ext_nanoarrow {
 
-//! Missing in nanoarrow_ipc.hpp
-struct UniqueSharedBuffer {
-  struct ArrowIpcSharedBuffer data{};
-
-  ~UniqueSharedBuffer() {
-    if (data.private_src.allocator.free != nullptr) {
-      ArrowIpcSharedBufferReset(&data);
-    }
-  }
-};
-
 struct ArrowIpcMessagePrefix {
   uint32_t continuation_token;
   int32_t metadata_size;

--- a/src/ipc/stream_reader/base_stream_reader.cpp
+++ b/src/ipc/stream_reader/base_stream_reader.cpp
@@ -95,14 +95,14 @@ bool IPCStreamReader::GetNextBatch(ArrowArray* out) {
     return false;
   }
 
-  // Use the ArrowIpcSharedBuffer if we have thread safety (i.e., if this was
+  // Use the ArrowSharedBuffer if we have thread safety (i.e., if this was
   // compiled with a compiler that supports C11 atomics, i.e., not gcc 4.8 or
   // MSVC)
-  bool thread_safe_shared = ArrowIpcSharedBufferIsThreadSafe();
+  bool thread_safe_shared = ArrowSharedBufferIsThreadSafe();
   struct ArrowBufferView body_view = AllocatedDataView(cur_ptr, cur_size);
   nanoarrow::UniqueBuffer body_shared = GetUniqueBuffer();
-  UniqueSharedBuffer shared;
-  NANOARROW_THROW_NOT_OK(ArrowIpcSharedBufferInit(&shared.data, body_shared.get()));
+  nanoarrow::UniqueBuffer shared;
+  NANOARROW_THROW_NOT_OK(ArrowSharedBufferInit(shared.get(), body_shared.get()));
   nanoarrow::UniqueArray array;
   if (HasProjection()) {
     NANOARROW_THROW_NOT_OK(ArrowArrayInitFromType(array.get(), NANOARROW_TYPE_STRUCT));
@@ -113,7 +113,7 @@ bool IPCStreamReader::GetNextBatch(ArrowArray* out) {
       for (int64_t i = 0; i < array->n_children; i++) {
         THROW_NOT_OK(InternalException, &error,
                      ArrowIpcDecoderDecodeArrayFromShared(
-                         decoder.get(), &shared.data, projected_fields[i],
+                         decoder.get(), shared.get(), projected_fields[i],
                          array->children[i], NANOARROW_VALIDATION_LEVEL_FULL, &error));
       }
     } else {
@@ -131,7 +131,7 @@ bool IPCStreamReader::GetNextBatch(ArrowArray* out) {
   } else if (thread_safe_shared) {
     THROW_NOT_OK(
         InternalException, &error,
-        ArrowIpcDecoderDecodeArrayFromShared(decoder.get(), &shared.data, -1, array.get(),
+        ArrowIpcDecoderDecodeArrayFromShared(decoder.get(), shared.get(), -1, array.get(),
                                              NANOARROW_VALIDATION_LEVEL_FULL, &error));
   } else {
     THROW_NOT_OK(InternalException, &error,

--- a/src/ipc/stream_reader/ipc_buffer_stream_reader.cpp
+++ b/src/ipc/stream_reader/ipc_buffer_stream_reader.cpp
@@ -58,6 +58,7 @@ bool IPCBufferStreamReader::DecodeHeader(idx_t message_header_size) {
 void IPCBufferStreamReader::DecodeBody() {
   if (decoder->body_size_bytes > 0) {
     body.ptr = ReadData(body.ptr, decoder->body_size_bytes);
+    body.size = decoder->body_size_bytes;
   }
   if (body.ptr) {
     cur_ptr = body.ptr;

--- a/test/sql/nanoarrow.test
+++ b/test/sql/nanoarrow.test
@@ -15,4 +15,4 @@ require nanoarrow
 query I
 SELECT nanoarrow_version();
 ----
-0.7.0-SNAPSHOT
+0.9.0


### PR DESCRIPTION
Updates the vendored nanoarrow archive to the 0.9.0 release commit and verifies its SHA256 checksum. Migrates IPC decoding to nanoarrow’s core shared-buffer API, which replaces the removed IPC-specific wrapper, and updates the version assertion.

Also resolved a drive by issue with an unset buffer size and aligned the Node check with the actual version of DuckDB CI is building.