### PR TITLE
feat(ipc): support dictionary-encoded reads

### DIFF
--- a/src/include/ipc/stream_reader/base_stream_reader.hpp
+++ b/src/include/ipc/stream_reader/base_stream_reader.hpp
@@ -84,6 +84,7 @@ class IPCStreamReader {
 
   ArrowError error{};
   nanoarrow::ipc::UniqueDecoder decoder{};
+  nanoarrow::ipc::UniqueDictionaries dictionaries{};
   vector<int64_t> projected_fields;
   nanoarrow::UniqueSchema projected_schema;
   //! Schema without projection applied to it

--- a/src/ipc/stream_reader/base_stream_reader.cpp
+++ b/src/ipc/stream_reader/base_stream_reader.cpp
@@ -60,15 +60,22 @@ const ArrowSchema* IPCStreamReader::GetBaseSchema() {
     throw IOException("This stream uses unsupported feature DICTIONARY_REPLACEMENT");
   }
 
-  // Decode the schema
+  // Decode the schema and retain its dictionary encoding information.
+  nanoarrow::ipc::UniqueDictionaryEncodings dictionary_encodings;
   THROW_NOT_OK(IOException, &error,
-               ArrowIpcDecoderDecodeSchema(decoder.get(), base_schema.get(), &error));
+               ArrowIpcDecoderDecodeSchemaWithDictionaries(
+                   decoder.get(), base_schema.get(), dictionary_encodings.get(), &error));
+
+  THROW_NOT_OK(
+      IOException, &error,
+      ArrowIpcDictionariesInit(dictionaries.get(), dictionary_encodings.get(), &error));
 
   // Set up the decoder to decode batches
   THROW_NOT_OK(InternalException, &error,
                ArrowIpcDecoderSetEndianness(decoder.get(), decoder->endianness));
   THROW_NOT_OK(InternalException, &error,
-               ArrowIpcDecoderSetSchema(decoder.get(), base_schema.get(), &error));
+               ArrowIpcDecoderSetSchemaWithDictionaries(
+                   decoder.get(), base_schema.get(), dictionary_encodings.get(), &error));
 
   return base_schema.get();
 }
@@ -84,21 +91,37 @@ const ArrowSchema* IPCStreamReader::GetOutputSchema() {
 }
 
 bool IPCStreamReader::GetNextBatch(ArrowArray* out) {
-  // When nanoarrow supports dictionary batches, we'd accept either a
-  // RecordBatch or DictionaryBatch message, recording the dictionary batch
-  // (or possibly ignoring it if it is for a field that we don't care about),
-  // but looping until we end up with a RecordBatch in the decoder.
-  ArrowIpcMessageType message_type =
-      ReadNextMessage({NANOARROW_IPC_MESSAGE_TYPE_RECORD_BATCH});
-  if (message_type == NANOARROW_IPC_MESSAGE_TYPE_UNINITIALIZED) {
-    out->release = nullptr;
-    return false;
+  const bool thread_safe_shared = ArrowSharedBufferIsThreadSafe();
+  while (true) {
+    ArrowIpcMessageType message_type =
+        ReadNextMessage({NANOARROW_IPC_MESSAGE_TYPE_RECORD_BATCH,
+                         NANOARROW_IPC_MESSAGE_TYPE_DICTIONARY_BATCH});
+    if (message_type == NANOARROW_IPC_MESSAGE_TYPE_UNINITIALIZED) {
+      out->release = nullptr;
+      return false;
+    }
+
+    if (message_type == NANOARROW_IPC_MESSAGE_TYPE_RECORD_BATCH) {
+      break;
+    }
+
+    struct ArrowBufferView body_view = AllocatedDataView(cur_ptr, cur_size);
+    nanoarrow::UniqueBuffer body_shared = GetUniqueBuffer();
+    if (thread_safe_shared) {
+      nanoarrow::UniqueBuffer shared;
+      NANOARROW_THROW_NOT_OK(ArrowSharedBufferInit(shared.get(), body_shared.get()));
+      THROW_NOT_OK(InternalException, &error,
+                   ArrowIpcDecoderDecodeDictionaryFromShared(
+                       decoder.get(), shared.get(), NANOARROW_VALIDATION_LEVEL_FULL,
+                       dictionaries.get(), &error));
+    } else {
+      THROW_NOT_OK(InternalException, &error,
+                   ArrowIpcDecoderDecodeDictionary(decoder.get(), body_view,
+                                                   NANOARROW_VALIDATION_LEVEL_FULL,
+                                                   dictionaries.get(), &error));
+    }
   }
 
-  // Use the ArrowSharedBuffer if we have thread safety (i.e., if this was
-  // compiled with a compiler that supports C11 atomics, i.e., not gcc 4.8 or
-  // MSVC)
-  bool thread_safe_shared = ArrowSharedBufferIsThreadSafe();
   struct ArrowBufferView body_view = AllocatedDataView(cur_ptr, cur_size);
   nanoarrow::UniqueBuffer body_shared = GetUniqueBuffer();
   nanoarrow::UniqueBuffer shared;
@@ -111,17 +134,19 @@ bool IPCStreamReader::GetNextBatch(ArrowArray* out) {
 
     if (thread_safe_shared) {
       for (int64_t i = 0; i < array->n_children; i++) {
-        THROW_NOT_OK(InternalException, &error,
-                     ArrowIpcDecoderDecodeArrayFromShared(
-                         decoder.get(), shared.get(), projected_fields[i],
-                         array->children[i], NANOARROW_VALIDATION_LEVEL_FULL, &error));
+        THROW_NOT_OK(
+            InternalException, &error,
+            ArrowIpcDecoderDecodeArrayFromSharedWithDictionaries(
+                decoder.get(), shared.get(), projected_fields[i], dictionaries.get(),
+                array->children[i], NANOARROW_VALIDATION_LEVEL_FULL, &error));
       }
     } else {
       for (int64_t i = 0; i < array->n_children; i++) {
-        THROW_NOT_OK(InternalException, &error,
-                     ArrowIpcDecoderDecodeArray(decoder.get(), body_view,
-                                                projected_fields[i], array->children[i],
-                                                NANOARROW_VALIDATION_LEVEL_FULL, &error));
+        THROW_NOT_OK(
+            InternalException, &error,
+            ArrowIpcDecoderDecodeArrayWithDictionaries(
+                decoder.get(), body_view, projected_fields[i], dictionaries.get(),
+                array->children[i], NANOARROW_VALIDATION_LEVEL_FULL, &error));
       }
     }
 
@@ -129,14 +154,15 @@ bool IPCStreamReader::GetNextBatch(ArrowArray* out) {
     array->length = array->children[0]->length;
     array->null_count = 0;
   } else if (thread_safe_shared) {
-    THROW_NOT_OK(
-        InternalException, &error,
-        ArrowIpcDecoderDecodeArrayFromShared(decoder.get(), shared.get(), -1, array.get(),
-                                             NANOARROW_VALIDATION_LEVEL_FULL, &error));
+    THROW_NOT_OK(InternalException, &error,
+                 ArrowIpcDecoderDecodeArrayFromSharedWithDictionaries(
+                     decoder.get(), shared.get(), -1, dictionaries.get(), array.get(),
+                     NANOARROW_VALIDATION_LEVEL_FULL, &error));
   } else {
     THROW_NOT_OK(InternalException, &error,
-                 ArrowIpcDecoderDecodeArray(decoder.get(), body_view, -1, array.get(),
-                                            NANOARROW_VALIDATION_LEVEL_FULL, &error));
+                 ArrowIpcDecoderDecodeArrayWithDictionaries(
+                     decoder.get(), body_view, -1, dictionaries.get(), array.get(),
+                     NANOARROW_VALIDATION_LEVEL_FULL, &error));
   }
 
   ArrowArrayMove(array.get(), out);

--- a/test/python/test_arrow_ipc_scan.py
+++ b/test/python/test_arrow_ipc_scan.py
@@ -79,7 +79,6 @@ class TestArrowIPCBufferRead(object):
             ):
                 connection.execute("FROM msg_reader")
 
-    @pytest.mark.skip(reason="Pending nanoarrow dictionary support")
     def test_dictionary_single_buffer(self, connection):
         indices = pa.array([0, 1, 0, 2, None, 1])
         dictionary = pa.array(["apple", "banana", "cherry"])
@@ -96,7 +95,6 @@ class TestArrowIPCBufferRead(object):
             res = connection.from_arrow(msg_reader).fetchall()
             assert res == [("apple",), ("banana",), ("apple",), ("cherry",), (None,), ("banana",)]
 
-    @pytest.mark.skip(reason="Pending nanoarrow dictionary support")
     def test_dictionary_multi_batch_stream(self, connection):
         indices1 = pa.array([0, 1])
         indices2 = pa.array([2, 0, None])
@@ -116,7 +114,6 @@ class TestArrowIPCBufferRead(object):
             res = connection.from_arrow(msg_reader).fetchall()
             assert res == [("alpha",), ("beta",), ("gamma",), ("alpha",), (None,)]
 
-    @pytest.mark.skip(reason="Pending nanoarrow dictionary support")
     def test_dictionary_unsigned_indices(self, connection):
         indices = pa.array([0, 1, 2], type=pa.uint8())
         dictionary = pa.array(["x", "y", "z"])
@@ -131,7 +128,6 @@ class TestArrowIPCBufferRead(object):
             msg_reader = ipc.MessageReader.open_stream(buf_reader)
             assert connection.from_arrow(msg_reader).fetchall() == [("x",), ("y",), ("z",)]
 
-    @pytest.mark.skip(reason="Pending nanoarrow dictionary support")
     def test_dictionary_null_in_values(self, connection):
         # Index points to a slot in the dictionary that is itself NULL
         indices = pa.array([0, 1, 2])
@@ -146,7 +142,6 @@ class TestArrowIPCBufferRead(object):
             msg_reader = ipc.MessageReader.open_stream(buf_reader)
             assert connection.from_arrow(msg_reader).fetchall() == [("apple",), (None,), ("cherry",)]
 
-    @pytest.mark.skip(reason="Pending nanoarrow dictionary support")
     def test_dictionary_shared_id(self, connection):
         # Two columns using the same dictionary
         dictionary = pa.array(["red", "green", "blue"])
@@ -168,7 +163,7 @@ class TestArrowIPCBufferRead(object):
             msg_reader = ipc.MessageReader.open_stream(buf_reader)
             assert connection.from_arrow(msg_reader).fetchall() == [("red", "blue"), ("green", "red")]
 
-    @pytest.mark.skip(reason="Pending nanoarrow dictionary support")
+    @pytest.mark.skip(reason="Nested dictionaries trigger a DuckDB Arrow conversion ownership error")
     def test_dictionary_inside_struct(self, connection):
         # Nested dictionary inside a Struct
         dictionary = pa.array(["low", "high"])
@@ -184,7 +179,6 @@ class TestArrowIPCBufferRead(object):
             msg_reader = ipc.MessageReader.open_stream(buf_reader)
             assert connection.from_arrow(msg_reader).fetchall() == [({'level': 'low'},), ({'level': 'high'},)]
 
-    @pytest.mark.skip(reason="Pending nanoarrow dictionary support")
     def test_dictionary_numeric_values(self, connection):
         indices = pa.array([0, 1, 0, None, 1], type=pa.int8())
         dictionary = pa.array([100.55, 200.75], type=pa.float64())
@@ -201,7 +195,6 @@ class TestArrowIPCBufferRead(object):
                 (100.55,), (200.75,), (100.55,), (None,), (200.75,)
             ]
 
-    @pytest.mark.skip(reason="Pending nanoarrow dictionary support")
     def test_dictionary_sliced_array(self, connection):
         indices = pa.array([0, 1, 2, 0, 1])
         dictionary = pa.array(["a", "b", "c"])
@@ -219,7 +212,7 @@ class TestArrowIPCBufferRead(object):
             msg_reader = ipc.MessageReader.open_stream(buf_reader)
             assert connection.from_arrow(msg_reader).fetchall() == [("c",), ("a",)]
 
-    @pytest.mark.skip(reason="Pending nanoarrow dictionary support")
+    @pytest.mark.skip(reason="nanoarrow cannot encode dictionary arrays")
     def test_duckdb_enum_to_arrow_ipc(self, connection):
         connection.execute("CREATE TYPE mood AS ENUM ('happy', 'sad', 'ok');")
         connection.execute("CREATE TABLE enum_t (id INT, m mood);")
@@ -241,7 +234,6 @@ class TestArrowIPCBufferRead(object):
             (1, "happy"), (2, "ok"), (3, None), (4, "sad")
         ]
 
-    @pytest.mark.skip(reason="Pending nanoarrow dictionary support")
     def test_dictionary_empty_batch(self, connection):
         indices = pa.array([], type=pa.int32())
         dictionary = pa.array(["unused"], type=pa.string())
@@ -256,7 +248,6 @@ class TestArrowIPCBufferRead(object):
             msg_reader = ipc.MessageReader.open_stream(buf_reader)
             assert connection.from_arrow(msg_reader).fetchall() == []
 
-    @pytest.mark.skip(reason="Pending nanoarrow dictionary support")
     def test_dictionary_large_string_values(self, connection):
         indices = pa.array([0, 1, 0])
         dictionary = pa.array(["v1", "v2"], type=pa.large_string())

--- a/test/python/test_arrow_ipc_scan.py
+++ b/test/python/test_arrow_ipc_scan.py
@@ -163,7 +163,7 @@ class TestArrowIPCBufferRead(object):
             msg_reader = ipc.MessageReader.open_stream(buf_reader)
             assert connection.from_arrow(msg_reader).fetchall() == [("red", "blue"), ("green", "red")]
 
-    @pytest.mark.skip(reason="Nested dictionaries trigger a DuckDB Arrow conversion ownership error")
+    @pytest.mark.skip(reason="Nested dictionary IPC ownership is not propagated correctly (issue #56)")
     def test_dictionary_inside_struct(self, connection):
         # Nested dictionary inside a Struct
         dictionary = pa.array(["low", "high"])

--- a/test/python/test_integration.py
+++ b/test/python/test_integration.py
@@ -31,9 +31,9 @@ little_big_integration_files = [
     "generated_primitive_zerolength.stream",
     "generated_primitive.stream",
     "generated_recursive_nested.stream",
-    # TODO: Uncomment this after adding support for dictionaries
-    # "generated_dictionary.stream",
-    # "generated_dictionary_unsigned.stream",
+    "generated_dictionary.stream",
+    "generated_dictionary_unsigned.stream",
+    # Nested dictionaries currently trigger a DuckDB Arrow conversion ownership error.
     # "generated_nested_dictionary.stream",
 ]
 

--- a/test/sql/arrow_testing.test
+++ b/test/sql/arrow_testing.test
@@ -21,6 +21,12 @@ statement ok
 FROM check_arrow_testing_file('1.0.0-littleendian/generated_datetime')
 
 statement ok
+FROM check_arrow_testing_file('1.0.0-littleendian/generated_dictionary')
+
+statement ok
+FROM check_arrow_testing_file('1.0.0-littleendian/generated_dictionary_unsigned')
+
+statement ok
 FROM check_arrow_testing_file('1.0.0-littleendian/generated_decimal')
 
 # This test will fail,because the struct created in this arrow file does not have names on their children


### PR DESCRIPTION
Update nanoarrow to 0.9.0 and use its dictionary-aware schema and array decoding APIs. Retain dictionary state across IPC messages, process dictionary batches before record batches, and support both projected and full-array decoding. Add Arrow integration coverage for signed and unsigned dictionary indices.

Tests:
- `build/release/test/unittest test/sql/arrow_testing.test`
- `build/release/test/unittest test/sql/nanoarrow.test`
- little- and big-endian dictionary fixture smoke tests

Nested struct dictionaries currently expose a separate DuckDB Arrow-conversion ownership assertion and are not included as a passing fixture.